### PR TITLE
Talos Countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,13 +27,12 @@
 
   <div class="leftpanel">
     <h2>About</h2>
-    <p>This version of the Talos Countdown was Forked and updated by Vomher in 2023. The Talos Countdown was originally created by <a href="https://github.com/AliceOrwell/SWL-Talos-Countdown">AliceOrwell</a>.</p>
     
     <p>This is a simple web interface intended to help players of the videogame
     <a href="https://www.secretworldlegends.com/">Secret World Legends</a> (SWL),
-    a MMORPG by <a href="https://www.funcom.com/">Funcom</a>. Its aim is to
+    an MMORPG by <a href="https://www.funcom.com/">Funcom</a>. Its aim is to
     provide information during the Talos of Gaia event regarding when each golem
-    will spawn within the Vibrant Agartha playfield in Agartha.</p>
+    will spawn within the Vibrant Agartha playfield of Agartha.</p>
 
     <p>Times are shown in the timezone set by your browser.</p>
 
@@ -96,7 +95,7 @@
 
     <h2>Feedback</h2>
 
-    <p>If something is broken, please let me know!</p>
+    <p>If something is broken,  <a href="https://twitter.com/Alice_Orwell">go ask Alice</a>.</p>
   </div>
   <div class="rightpanel">
     <div id="current_time" class="current_time"></div>

--- a/index.html
+++ b/index.html
@@ -27,11 +27,13 @@
 
   <div class="leftpanel">
     <h2>About</h2>
+    <p>This version of the Talos Countdown was Forked and updated by Vomher in 2023. The Talos Countdown was originally created by <a href="https://github.com/AliceOrwell/SWL-Talos-Countdown">AliceOrwell</a>.</p>
+    
     <p>This is a simple web interface intended to help players of the videogame
     <a href="https://www.secretworldlegends.com/">Secret World Legends</a> (SWL),
     a MMORPG by <a href="https://www.funcom.com/">Funcom</a>. Its aim is to
     provide information during the Talos of Gaia event regarding when each golem
-    will be spawned in Agartha.</p>
+    will spawn within the Vibrant Agartha playfield in Agartha.</p>
 
     <p>Times are shown in the timezone set by your browser.</p>
 
@@ -94,7 +96,7 @@
 
     <h2>Feedback</h2>
 
-    <p>If something is broken <a href="https://twitter.com/Alice_Orwell">go ask Alice</a>.</p>
+    <p>If something is broken, please let me know!</p>
   </div>
   <div class="rightpanel">
     <div id="current_time" class="current_time"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -51,10 +51,10 @@ var settings = {
   update_freq: 1000,
 
   // When the event ends
-  event_end: "2022-07-17T13:00:00+00:00",          // Assumed end date
+  event_end: "2023-07-16T13:00:00+00:00",          // Assumed end date
 
   // Known occurance of a golem. Used to calculate all other golem times.
-  known_golem_time: "2018-06-22T06:00:00+00:00",
+  known_golem_time: "2023-06-24T13:00:00+00:00",
   // Index in golems array for known golem
   known_golem_index: 0,                            // Magma golem
 


### PR DESCRIPTION
Updated the Talos Countdown for the Sixth Anniversary (2023) and made a few grammatical changes!

Fun fact: Technically the Talos continue to spawn regardless of whether or not the Anniversary event is active - we just can't reach Vibrant Agartha when it's not the Anniversary!